### PR TITLE
Improve IAM example

### DIFF
--- a/day04-iam/README.md
+++ b/day04-iam/README.md
@@ -1,13 +1,17 @@
 # Day 4 – AWS IAM
 
-This setup includes:
-- An IAM user named `dev-user`
-- A custom policy with read-only S3 access
-- The policy attached to the user
-- A role for Lambda execution
+This example provisions a simple IAM setup:
+- an IAM user and group
+- a custom policy granting read-only access to S3
+- the policy attached to the group the user belongs to
+- a role for Lambda functions with the basic execution policy attached
 
 ## Usage
 
 ```bash
 terraform init
 terraform apply
+
+# Once finished, clean up
+terraform destroy
+```

--- a/day04-iam/main.tf
+++ b/day04-iam/main.tf
@@ -1,44 +1,73 @@
+variable "region" {
+  description = "AWS region"
+  default     = "us-east-1"
+}
+
+variable "user_name" {
+  description = "IAM user name"
+  default     = "dev-user"
+}
+
+variable "group_name" {
+  description = "IAM group name"
+  default     = "dev-group"
+}
+
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
+}
+
+resource "aws_iam_group" "dev_group" {
+  name = var.group_name
 }
 
 resource "aws_iam_user" "dev_user" {
-  name = "dev-user"
+  name = var.user_name
+}
+
+resource "aws_iam_group_membership" "dev_membership" {
+  name  = "${var.group_name}-membership"
+  users = [aws_iam_user.dev_user.name]
+  group = aws_iam_group.dev_group.name
+}
+
+data "aws_iam_policy_document" "s3_read" {
+  statement {
+    actions   = ["s3:Get*", "s3:List*"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
 }
 
 resource "aws_iam_policy" "s3_read_policy" {
   name        = "S3ReadOnly"
   description = "Allow read-only access to S3"
-  policy      = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = [
-        "s3:Get*",
-        "s3:List*"
-      ]
-      Effect   = "Allow"
-      Resource = "*"
-    }]
-  })
+  policy      = data.aws_iam_policy_document.s3_read.json
 }
 
-resource "aws_iam_user_policy_attachment" "attach_s3_read" {
-  user       = aws_iam_user.dev_user.name
+resource "aws_iam_group_policy_attachment" "attach_s3_read" {
+  group      = aws_iam_group.dev_group.name
   policy_arn = aws_iam_policy.s3_read_policy.arn
 }
 
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role" "lambda_exec_role" {
-  name = "lambda-exec-role"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole",
-        Effect = "Allow",
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
-      }
-    ]
-  })
+  name               = "lambda-exec-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda_exec_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }


### PR DESCRIPTION
## Summary
- enhance day 4 IAM example with variables and groups
- attach S3 policy to group and give Lambda role basic permissions
- update day 4 README with clearer instructions

## Testing
- `terraform fmt -check day04-iam/main.tf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868231b4a98832b85f7f6e61337a152